### PR TITLE
Small refactoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,19 +26,19 @@
 
   <groupId>io.openshift.booster</groupId>
   <artifactId>spring-boot-booster-parent</artifactId>
-  <version>1.5.8-SNAPSHOT</version>
+  <version>1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Spring Boot Tomcat - Booster Parent</name>
   <description>Spring Boot Tomcat - Booster Parent</description>
 
   <properties>
-    <spring-boot.version>1.5.8</spring-boot.version>
-    <snowdrop.qualifier>.Final</snowdrop.qualifier>
     <java.version>1.8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <junit.version>4.12</junit.version>
+    <spring-boot-bom.version>1.5.8.Final</spring-boot-bom.version>
+    <spring-boot-maven-plugin.version>1.5.8.RELEASE</spring-boot-maven-plugin.version>
   </properties>
 
   <repositories>
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>me.snowdrop</groupId>
         <artifactId>spring-boot-bom</artifactId>
-        <version>${spring-boot.version}${snowdrop.qualifier}</version>
+        <version>${spring-boot-bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -68,7 +68,6 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
-
 
   <licenses>
     <license>
@@ -110,6 +109,7 @@
           <include>**/application*.properties</include>
           <include>**/boostrap.properties</include>
           <include>**/fabric8/*.yml</include>
+          <include>**/logback*.xml</include>
         </includes>
       </testResource>
     </testResources>
@@ -119,7 +119,7 @@
         <plugin>
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
-          <version>${spring-boot.version}.RELEASE</version>
+          <version>${spring-boot-maven-plugin.version}</version>
           <configuration>
             <classifier>exec</classifier>
           </configuration>
@@ -134,7 +134,6 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>${maven-failsafe-plugin.version}</version>
           <executions>
             <execution>
               <goals>
@@ -146,6 +145,13 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 
   <profiles>
@@ -156,12 +162,10 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>license-maven-plugin</artifactId>
-            <inherited>false</inherited>
           </plugin>
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>xml-maven-plugin</artifactId>
-            <inherited>false</inherited>
           </plugin>
         </plugins>
       </build>
@@ -193,14 +197,6 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>integration-test</goal>
-                  <goal>verify</goal>
-                </goals>
-              </execution>
-            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
@metacosm I did a couple of small changes to the parent. Let me know if you agree:

1. Use the same versioning scheme as booster-parent and boosters rather than tie it to the spring-boot-bom version.
2. Explicitly define spring-boot-bom and spring-boot-maven-plugin versions instead of using pieces and appending them in different places. I think defining qualifiers and parts of the version introduces complexity with a very small benefit. Keeping in mind that these are only two properties, I think it would make things clearer and easier to maintain to simply have version properties.
3. Include logback to the test resources.
4. Remove redundant config of failsafe plugin.

I've tried it with http and circuit breaker boosters and all works fine. 