### PR TITLE
chore: bumps booster parent and arquillian dependencies version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>io.openshift</groupId>
     <artifactId>booster-parent</artifactId>
-    <version>20</version>
+    <version>21</version>
   </parent>
 
   <groupId>io.openshift.booster</groupId>
@@ -81,7 +81,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <arquillian.version>1.3.0.Final</arquillian.version>
+    <arquillian.version>1.4.0.Final</arquillian.version>
     <junit.version>4.12</junit.version>
     <spring-boot-bom.version>1.5.10.SP3</spring-boot-bom.version>
     <spring-boot.version>1.5.10.RELEASE</spring-boot.version>


### PR DESCRIPTION
- Bumps Booster Parent version from 20 to 21.
- Bumps Arquillian version from 1.3.0.Final to 1.4.0.Final